### PR TITLE
Move tool-specific setup to bottom of .zshrc

### DIFF
--- a/.zshrc
+++ b/.zshrc
@@ -15,13 +15,6 @@ PROMPT_COMMAND="history -a; history -c; history -r; ${PROMPT_COMMAND}"
 # If you come from bash you might have to change your $PATH.
 # export PATH=$HOME/bin:$HOME/.local/bin:/usr/local/bin:$PATH
 
-# If using Go:
-# export PATH=/usr/local/go/bin:$HOME/go/bin:$PATH
-
-# If using rbenv:
-# export PATH=$HOME/.rbenv/shims:$PATH
-# eval "$(rbenv init -)"
-
 # Path to your Oh My Zsh installation.
 export ZSH="$HOME/.oh-my-zsh"
 
@@ -127,3 +120,9 @@ source $ZSH/oh-my-zsh.sh
 alias grep='grep -rin --color'
 alias diff='colordiff'
 
+# If using Go:
+# export PATH=/usr/local/go/bin:$HOME/go/bin:$PATH
+
+# If using rbenv:
+# export PATH=$HOME/.rbenv/shims:$PATH
+# eval "$(rbenv init -)"


### PR DESCRIPTION
When tools automatically update .zshrc to add tool-specific commands, these steps are appended to the end of the file. This moves the existing (but commented out) tool-specific commands to the end of .zshrc to match what the tool would do on its own.