### PR TITLE
Add .gitconfig file

### DIFF
--- a/.gitconfig
+++ b/.gitconfig
@@ -1,0 +1,7 @@
+[user]
+	name = Molly Waggett
+	# Update 'email' if you want a different email address associated with
+	# your commits, e.g. a job email address
+	email = mollyrwaggett@gmail.com
+[core]
+	excludesfile = ~/.gitignore_global


### PR DESCRIPTION
This commit adds a `.gitconfig` file, used for git configuration settings to be used at the global level. Any project-specific configuration should be in the `.git/config` file in the project's root directory.